### PR TITLE
修改dingtalk签名base64问题

### DIFF
--- a/lib/helper/notify.js
+++ b/lib/helper/notify.js
@@ -430,7 +430,7 @@ function ddBotNotify(text, desp) {
             const dateNow = Date.now();
             const hmac = crypto.createHmac('sha256', DD_BOT_SECRET);
             hmac.update(`${dateNow}\n${DD_BOT_SECRET}`);
-            const result = encodeURIComponent(hmac.digest('Util64'));
+            const result = encodeURIComponent(hmac.digest().toString('base64'));
             send({
                 method: 'POST',
                 url: `https://oapi.dingtalk.com/robot/send`,


### PR DESCRIPTION
老得方法报错 
sign not match, more: [https://ding-doc.dingtalk.com/doc#/serverapi2/qf2nxq]