### PR TITLE
fix: prevent is_repost_then_chat from overriding AI-generated comments

### DIFF
--- a/lib/core/monitor.js
+++ b/lib/core/monitor.js
@@ -255,6 +255,7 @@ class Monitor extends Searcher {
      * @property {string} [rid] 评论标识
      * @property {number} chat_type 评论类型
      * @property {string} [chat] 评论词
+     * @property {boolean} [isAiChat] 是否为AI生成的评论
      */
     /**
      * @returns {Promise<LotteryOptions[]>}
@@ -541,6 +542,7 @@ class Monitor extends Searcher {
                                 ai_comments_parm.prompt,
                                 lottery_info.des) || '!!!';
                             log.info('获取到Ai评论内容', `${onelotteryinfo.chat}`);
+                            onelotteryinfo.isAiChat = true;
                         } catch (e) {
                             log.error('获取AI评论失败，使用随机评论', e);
                             onelotteryinfo.chat = (getRandomOne(chats) || '!!!').replace(/\$\{uname\}/g, uname);
@@ -600,7 +602,7 @@ class Monitor extends Searcher {
 
         let
             status = 0,
-            { uid, dyid, chat_type, rid, relay_chat, ctrl, chat } = option,
+            { uid, dyid, chat_type, rid, relay_chat, ctrl, chat, isAiChat } = option,
             { check_if_duplicated, is_copy_chat, copy_blockword, is_repost_then_chat, is_not_create_partition } = config;
 
         /* 评论 */
@@ -616,7 +618,11 @@ class Monitor extends Searcher {
                         global_var.get('myUNAME') || '');
             } else {
                 if (is_repost_then_chat) {
-                    chat = chat + relay_chat;
+                    if (isAiChat) {
+                        relay_chat = chat;
+                    } else {
+                        chat = chat + relay_chat;
+                    }
                 }
             }
 


### PR DESCRIPTION
When AI comments are enabled and successfully generated, the is_repost_then_chat option would overwrite the AI comment with relay_chat. This fix adds an isAiChat flag so that:
- When AI comment exists: relay_chat is set to the AI comment instead
- When no AI comment: original behavior (chat += relay_chat) is preserved